### PR TITLE
Bugfix: wrong reading length in test_uds

### DIFF
--- a/debug/comm/test_uds_client.c
+++ b/debug/comm/test_uds_client.c
@@ -29,7 +29,7 @@ int main()
 	}
 	EGUI_PRINT_INFO("connect to server successfully!");
 
-	if(uds_read(&server_uds, buf, sizeof(buf)) < 0)
+	if(uds_read(&server_uds, buf, sizeof(SERVER_MSG)) < 0)
 	{
 		EGUI_PRINT_ERROR("failed to read server msg");
 		return -1;

--- a/debug/comm/test_uds_server.c
+++ b/debug/comm/test_uds_server.c
@@ -43,7 +43,7 @@ int main()
 	}
 	EGUI_PRINT_INFO("write %s successfully", SERVER_MSG);
 
-	if(uds_read(&client_uds, buf, sizeof(buf)) < 0)
+	if(uds_read(&client_uds, buf, sizeof(CLIENT_MSG)) < 0)
 	{
 		EGUI_PRINT_ERROR("failed to read client msg");
 		return -1;


### PR DESCRIPTION
原来的代码必须强制结束客户端才能看到服务器的响应，那是因为给uds_read的读取长度大于要读的数据，导致在uds_read里等待。

在已经知道数据长度的情况下，应该将数据长度（而不是buffer长度）传给uds_read。
